### PR TITLE
j_master compact layouts, and single-species cliff cloning

### DIFF
--- a/acnh/garden_layouts.html
+++ b/acnh/garden_layouts.html
@@ -662,7 +662,7 @@
                             <th>How to tile:</th>
                             <td>You can tile it horizontally like picture A. To tile the layout vertically, put one
                                 extra space inbetween like picture B (to minimize failure rate), or put down a row of
-                                stone path.</td>
+                                stone path between the vertically tiled sections.</td>
                         </tr>
                         <tr>
                             <td style="text-align:right; font-weight: bold;">A</td>

--- a/acnh/garden_layouts.html
+++ b/acnh/garden_layouts.html
@@ -661,7 +661,8 @@
                         <tr>
                             <th>How to tile:</th>
                             <td>You can tile it horizontally like picture A. To tile the layout vertically, put one
-                                extra space inbetween like picture B (to minimize failure rate).</td>
+                                extra space inbetween like picture B (to minimize failure rate), or put down a row of
+                                stone path.</td>
                         </tr>
                         <tr>
                             <td style="text-align:right; font-weight: bold;">A</td>
@@ -885,7 +886,7 @@
             </ul>
             <h3>References:</h3>
             <ul class="bullet-list">
-                <li><a href="https://cdn.discordapp.com/attachments/694317725190717440/712583018732322826/12x12_breed_all_flowers_final6.png"
+                <li><a href="https://cdn.discordapp.com/attachments/694317725190717440/709139692788121720/Layouts_final1.png"
                         target="_blank">J_MASTER's Space-Efficient Layouts Guide</a> (<a
                         href="https://twitter.com/GigaRoboid" target="_blank">@GigaRoboid</a>)
                 </li>


### PR DESCRIPTION
fixes the link to j_master's compact layouts guide (currently links the 12x12), and adds a note that you can put a row of stone path down between vertically tiled cliff cloning segments